### PR TITLE
fix: replacement policy giving random values

### DIFF
--- a/src/cache/cache-set.ts
+++ b/src/cache/cache-set.ts
@@ -81,12 +81,12 @@ export class CacheSet {
             return [invalidBlock, ReplacementReason.Invalid];
         }
 
-        if (this.cache.parameters.policy === 'LRU') {
+        if (this.cache.parameters.policy.toUpperCase() === 'LRU') {
             // TODO why undefined is returned?
             return [this.getLruReplacementBlock() as CacheBlock, ReplacementReason.Lru];
         }
 
-        if (this.cache.parameters.policy === 'FIFO') {
+        if (this.cache.parameters.policy.toUpperCase() === 'FIFO') {
             // TODO why undefined is returned?
             return [this.getFifoReplacementBlock() as CacheBlock, ReplacementReason.Fifo];
         }

--- a/src/components/configurator-modal/index.tsx
+++ b/src/components/configurator-modal/index.tsx
@@ -175,19 +175,19 @@ export const ConfiguratorModal = ({initialCaches, open, onCreate, onClose}: Conf
                             label="Replacement Policy"
                         >
                             <Select
-                                defaultValue="lru"
+                                defaultValue="LRU"
                                 onChange={value => {
                                     updateCache(selectedCache, 'policy', value as 'LRU' | 'FIFO')
                                 }}
                                 options={[
                                     {
-                                        value: 'lru', label: <div className="flex items-center gap-1">
+                                        value: 'LRU', label: <div className="flex items-center gap-1">
                                             <Clock className="w-4"/>
                                             <span>LRU (Least Recently Used)</span>
                                         </div>,
                                     },
                                     {
-                                        value: 'fifo',
+                                        value: 'FIFO',
                                         label: <div className="flex items-center gap-1">
                                             <ListRestart className="w-4"/>
                                             <span>FIFO (First In, First Out)</span>


### PR DESCRIPTION
This PR fixes the warning giving an unknown replacement policy, falling the policy to random, who also gives incorrect results.
Since the code was comparing `'lru' === 'LRU'` or `'fifo' === 'FIFO'`, which returns false, I added a `toUpperCase()` before the comparison to fix it.

![Example](https://github.com/user-attachments/assets/9359440c-06fb-46cb-a71e-824a2307101d)
